### PR TITLE
Fix stale otter count on the channel a member moves away from

### DIFF
--- a/src/vudrochka_bot/cogs/voice_status.py
+++ b/src/vudrochka_bot/cogs/voice_status.py
@@ -35,14 +35,32 @@ class VoiceStatusCog(commands.Cog):
         if before.channel == after.channel:
             return
 
-        # A move touches two channels; a join/leave touches one. ``dict.fromkeys``
-        # de-duplicates while preserving order and dropping ``None``.
-        for channel in dict.fromkeys((before.channel, after.channel)):
-            if isinstance(channel, discord.VoiceChannel):
-                await self._update_status(channel)
+        # A move fires a single event touching two channels; a join/leave touches
+        # one. Recompute each, but don't trust ``channel.members`` to reflect the
+        # move yet: on a direct move discord can still list the member in the
+        # channel they *left*, which left a stale otter there. So subtract the
+        # member from the channel they left and add them to the one they joined.
+        if isinstance(before.channel, discord.VoiceChannel):
+            await self._update_status(before.channel, left=member)
+        if isinstance(after.channel, discord.VoiceChannel):
+            await self._update_status(after.channel, joined=member)
 
-    async def _update_status(self, channel: discord.VoiceChannel) -> None:
-        status = format_status(len(channel.members))
+    async def _update_status(
+        self,
+        channel: discord.VoiceChannel,
+        *,
+        joined: discord.Member | None = None,
+        left: discord.Member | None = None,
+    ) -> None:
+        # Count from the channel's members, correcting for the in-flight move so
+        # the result doesn't depend on whether discord's cache has caught up yet.
+        member_ids = {m.id for m in channel.members}
+        if joined is not None:
+            member_ids.add(joined.id)
+        if left is not None:
+            member_ids.discard(left.id)
+
+        status = format_status(len(member_ids))
         try:
             await channel.edit(status=status, reason="member count changed")
         except discord.Forbidden:

--- a/tests/test_voice_status.py
+++ b/tests/test_voice_status.py
@@ -1,0 +1,90 @@
+"""Tests for the voice-status cog's move/join/leave handling.
+
+The cog's handler is async; rather than pull in pytest-asyncio we just drive the
+coroutine with ``asyncio.run``. Discord objects are mocked — ``spec=`` makes the
+``isinstance(..., discord.VoiceChannel)`` guard pass, and a channel's ``.members``
+is whatever we set it to.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+
+from vudrochka_bot.cogs.voice_status import VoiceStatusCog
+from vudrochka_bot.pluralization import format_status
+
+
+def _member(member_id: int) -> MagicMock:
+    member = MagicMock()
+    member.id = member_id
+    return member
+
+
+def _voice_channel(members: list[MagicMock], *, channel_id: int) -> MagicMock:
+    channel = MagicMock(spec=discord.VoiceChannel)
+    channel.members = members
+    channel.name = "general"
+    channel.id = channel_id
+    channel.edit = AsyncMock()
+    return channel
+
+
+def _state(channel: MagicMock | None) -> MagicMock:
+    state = MagicMock()
+    state.channel = channel
+    return state
+
+
+def _dispatch(member: MagicMock, before: MagicMock | None, after: MagicMock | None) -> None:
+    cog = VoiceStatusCog(MagicMock())
+    asyncio.run(cog.on_voice_state_update(member, _state(before), _state(after)))
+
+
+def _status_set_on(channel: MagicMock) -> str:
+    channel.edit.assert_awaited_once()
+    return channel.edit.await_args.kwargs["status"]
+
+
+def test_move_clears_the_old_channel_even_if_member_still_listed() -> None:
+    # Regression: on a direct move discord may still list the mover in the
+    # channel they left. The old code counted them and left a stale otter.
+    mover = _member(1)
+    old = _voice_channel([mover], channel_id=10)  # not dropped from .members yet
+    new = _voice_channel([mover, _member(2)], channel_id=20)
+
+    _dispatch(mover, old, new)
+
+    assert _status_set_on(old) == "Немає ВиДрочок"
+    assert _status_set_on(new) == format_status(2)
+
+
+def test_join_counts_the_new_member() -> None:
+    joiner = _member(1)
+    channel = _voice_channel([joiner], channel_id=10)
+
+    _dispatch(joiner, None, channel)
+
+    assert _status_set_on(channel) == format_status(1)
+
+
+def test_leave_drops_the_member_even_if_still_listed() -> None:
+    leaver = _member(1)
+    channel = _voice_channel([leaver], channel_id=10)  # still listed at dispatch
+
+    _dispatch(leaver, channel, None)
+
+    assert _status_set_on(channel) == "Немає ВиДрочок"
+
+
+def test_mute_toggle_in_place_is_ignored() -> None:
+    member = _member(1)
+    channel = _voice_channel([member], channel_id=10)
+
+    # before.channel is after.channel — only mute/deafen changed.
+    cog = VoiceStatusCog(MagicMock())
+    asyncio.run(cog.on_voice_state_update(member, _state(channel), _state(channel)))
+
+    channel.edit.assert_not_awaited()


### PR DESCRIPTION
## Bug

Moving directly from one voice channel to another left a **stale otter count on the channel the member moved away from** — the old VC kept showing its previous count instead of dropping by one (or clearing to `Немає ВиДрочок` when it emptied).

## Cause

A direct move fires a single `on_voice_state_update` touching two channels. The handler recomputed each channel from `len(channel.members)`, but on a move discord can still list the moving member in the channel they **left** at dispatch time — so the old channel's recomputed count still included them.

## Fix

Make the count independent of discord's cache timing: subtract the member from the channel they left and add them to the one they joined, rather than trusting `channel.members` to already reflect the move. This also hardens the plain join/leave paths.

## Tests

Adds `tests/test_voice_status.py` (move / join / leave / mute-in-place no-op). The move and leave cases deliberately set up `channel.members` to *still* include the departing member, so they fail on the old code and pass on the fix. The async handler is driven via `asyncio.run` — no new test dependency. Full suite: **27 passed** (verified in the Linux Docker image), `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)