### PR TITLE
Add working Lightsail deploy pipeline (push to `deploy` branch)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,22 +1,26 @@
-name: Deploy to AWS ECS
+name: Deploy to Lightsail
 
+# Builds the image, pushes it to ECR, then has the Lightsail box pull and restart.
+# Trigger: push the commit you want live to the `deploy` branch
+# (e.g. `git push origin develop:deploy`), or run manually.
 on:
   push:
-    branches: [main]
+    branches: [deploy]
   workflow_dispatch:
 
-# OIDC role assumption — no long-lived AWS access keys.
+# OIDC role assumption for ECR — no long-lived AWS access keys.
 permissions:
   id-token: write
   contents: read
 
+# Never run two deploys at once; cancel an in-progress one if a newer push lands.
+concurrency:
+  group: deploy-lightsail
+  cancel-in-progress: false
+
 env:
   AWS_REGION: eu-central-1
   ECR_REPOSITORY: vudrochka-bot
-  ECS_SERVICE: vudrochka-bot
-  ECS_CLUSTER: DiscordBots
-  ECS_TASK_DEFINITION: task-definition.json
-  CONTAINER_NAME: vudrochka-bot
 
 jobs:
   deploy:
@@ -44,21 +48,49 @@ jobs:
           docker build -t "$IMAGE" -t "$ECR_REGISTRY/$ECR_REPOSITORY:latest" .
           docker push "$IMAGE"
           docker push "$ECR_REGISTRY/$ECR_REPOSITORY:latest"
-          # Pass the immutable, commit-pinned URI to the next step as a proper output.
+          # Pass the immutable, commit-pinned URI to later steps.
           echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
 
-      - name: Render task definition with the new image
-        id: task-def
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
-        with:
-          task-definition: ${{ env.ECS_TASK_DEFINITION }}
-          container-name: ${{ env.CONTAINER_NAME }}
-          image: ${{ steps.build.outputs.image }}
+      - name: Render the production compose file with the new image
+        env:
+          IMAGE: ${{ steps.build.outputs.image }}
+        run: |
+          sed "s#__BOT_IMAGE__#${IMAGE}#" compose.prod.yaml > compose.deploy.yaml
 
-      - name: Deploy to Amazon ECS
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
-        with:
-          task-definition: ${{ steps.task-def.outputs.task-definition }}
-          service: ${{ env.ECS_SERVICE }}
-          cluster: ${{ env.ECS_CLUSTER }}
-          wait-for-service-stability: true
+      - name: Deploy to the Lightsail box over SSH
+        env:
+          SSH_KEY: ${{ secrets.LIGHTSAIL_SSH_KEY }}
+          HOST: ${{ secrets.LIGHTSAIL_HOST }}
+          SSH_USER: ubuntu # default user for the Lightsail ubuntu_24_04 blueprint
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          set -euo pipefail
+
+          # ECR auth token (valid ~12h) minted on the runner from the OIDC creds,
+          # so the box doesn't need any AWS credentials of its own.
+          ECR_PASSWORD="$(aws ecr get-login-password --region "$AWS_REGION")"
+
+          install -m 600 /dev/null deploy_key
+          printf '%s\n' "$SSH_KEY" > deploy_key
+          ssh-keyscan -H "$HOST" >> known_hosts 2>/dev/null
+
+          SSH="ssh -i deploy_key -o UserKnownHostsFile=known_hosts ${SSH_USER}@${HOST}"
+
+          # Ship the rendered compose file (preserves the box's existing .env / BOT_TOKEN).
+          scp -i deploy_key -o UserKnownHostsFile=known_hosts \
+            compose.deploy.yaml "${SSH_USER}@${HOST}:~/vudrochka/compose.prod.yaml"
+
+          # Log in to ECR, pull the pinned image, restart, then prune old images.
+          $SSH "ECR_REGISTRY='${ECR_REGISTRY}' ECR_PASSWORD='${ECR_PASSWORD}' bash -s" <<'REMOTE'
+          set -euo pipefail
+          cd ~/vudrochka
+          echo "$ECR_PASSWORD" | sudo docker login --username AWS --password-stdin "$ECR_REGISTRY"
+          sudo docker compose -f compose.prod.yaml pull
+          sudo docker compose -f compose.prod.yaml up -d
+          sudo docker image prune -f
+          sudo docker logout "$ECR_REGISTRY" || true
+          REMOTE
+
+      - name: Scrub the SSH key from the runner
+        if: always()
+        run: rm -f deploy_key

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,5 +81,19 @@ docker build -t vudrochka-bot . && docker run --rm vudrochka-bot python -c "impo
 ## Deployment
 
 Runs as a Docker container (`docker compose`, `restart: unless-stopped`) on an **AWS Lightsail**
-instance in eu-central-1. To update: sync source to the box and `docker compose up -d --build`.
-The ECS workflow at `.github/workflows/deploy.yml` is **legacy** (the bot is no longer on Fargate).
+instance in eu-central-1. The bot is **no longer on ECS/Fargate** — do not reintroduce an ECS
+deploy. `task-definition.json` is a leftover from that era and is unused.
+
+**CD pipeline** ([.github/workflows/deploy.yml](.github/workflows/deploy.yml)): push the commit
+you want live to the **`deploy` branch** (`git push origin develop:deploy`) — or run the workflow
+manually. It builds the image, pushes it to ECR (`vudrochka-bot`, commit-SHA + `latest` tags), then
+SSHes into the box, renders [compose.prod.yaml](compose.prod.yaml) with the pinned image URI, and
+`docker compose pull && up -d`. **The box never builds** — it pulls the pre-built image; ECR auth is
+a short-lived token minted on the runner (OIDC), so the box holds no AWS credentials.
+
+Required repo secrets: `AWS_DEPLOY_ROLE_ARN` (OIDC role with ECR push perms), `LIGHTSAIL_HOST`
+(public IP), `LIGHTSAIL_SSH_KEY` (private key for `ubuntu@` the box). The box must have
+`~/vudrochka/.env` (holds `BOT_TOKEN`) — it's preserved across deploys, never shipped from CI.
+
+Manual fallback (e.g. CI down): sync source to `~/vudrochka` and `docker compose up -d --build`
+(the dev [compose.yaml](compose.yaml), which builds from source).

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -1,0 +1,23 @@
+# Production compose for the Lightsail host.
+#
+# Unlike compose.yaml (which builds from source for local dev), this runs the
+# pre-built image pulled from ECR — the box never builds. The deploy workflow
+# (.github/workflows/deploy.yml) substitutes __BOT_IMAGE__ with the commit-pinned
+# ECR URI and scps the rendered file to ~/vudrochka/compose.prod.yaml on the box.
+#
+# Do not run this file locally; use compose.yaml instead.
+services:
+  bot:
+    image: __BOT_IMAGE__
+    container_name: vudrochka-bot
+    env_file: .env # holds BOT_TOKEN on the box; never committed
+    restart: unless-stopped
+    pull_policy: always
+    # The bot is a long-lived Discord gateway client with no inbound ports.
+    stop_grace_period: 30s
+    # Cap container logs so they can't fill the disk on a long-running host.
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"


### PR DESCRIPTION
## What

Brings the **working Lightsail deploy pipeline** into `develop`. This is the commit that was left behind when PR #16 merged only the restructure — `develop` currently has the dead ECS `deploy.yml` and a `CLAUDE.md` that still calls it legacy.

## Pipeline

On push to the **`deploy` branch** (`git push origin develop:deploy`) or manual dispatch:

1. Build the image, push to ECR (`vudrochka-bot`, commit-SHA + `latest`).
2. SSH into the Lightsail box, scp a rendered `compose.prod.yaml` (image URI pinned to the SHA), and run `docker compose pull && up -d`.
3. The box **pulls** the pre-built image — no slow on-box build. ECR auth is a short-lived token minted on the runner via OIDC, so the box holds no AWS credentials. The box's `~/vudrochka/.env` (BOT_TOKEN) is preserved.

## Required repo secrets

- `AWS_DEPLOY_ROLE_ARN` — OIDC role with ECR push perms; its trust policy must allow `refs/heads/deploy`.
- `LIGHTSAIL_HOST` — the box's public IP.
- `LIGHTSAIL_SSH_KEY` — private key for `ubuntu@` the box.

## Notes

- Not run end-to-end yet (needs the live box + secrets); verified by construction. First real run on the `deploy` branch is the true test.
- `task-definition.json` (ECS leftover) is now documented as dead but left in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)