### PR TITLE
Auto-deploy on merge to develop (gated on lint+tests)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,10 @@
 name: CI
 
+# Validates pull requests. Pushes to `develop` are validated by the deploy
+# workflow's test gate instead, so we don't run the same checks twice per merge.
 on:
-  push:
-    branches: [develop, main]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,14 +1,14 @@
 name: Deploy to Lightsail
 
-# Builds the image, pushes it to ECR, then has the Lightsail box pull and restart.
-# Trigger: push the commit you want live to the `deploy` branch
-# (e.g. `git push origin develop:deploy`), or run manually.
+# Lints + tests, then builds the image, pushes it to ECR, and has the Lightsail
+# box pull and restart. Runs on every push to `develop` (i.e. every merge) and
+# can also be run manually. The deploy only happens if lint + tests pass.
 #
 # No GitHub secrets: AWS is reached via OIDC role assumption, and the deploy
 # target (host + SSH key) is pulled from AWS Secrets Manager at run time.
 on:
   push:
-    branches: [deploy]
+    branches: [develop]
   workflow_dispatch:
 
 permissions:
@@ -29,7 +29,27 @@ env:
   DEPLOY_ROLE_ARN: arn:aws:iam::126568927381:role/github-actions-vudrochka-deploy
 
 jobs:
+  # Gate: never deploy code that doesn't lint and pass tests.
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.11.25"
+          enable-cache: true
+      - name: Install dependencies
+        run: uv sync --locked --dev
+      - name: Lint (ruff)
+        run: |
+          uv run ruff check .
+          uv run ruff format --check .
+      - name: Test (pytest)
+        run: uv run pytest
+
   deploy:
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,12 +84,13 @@ Runs as a Docker container (`docker compose`, `restart: unless-stopped`) on an *
 instance in eu-central-1. The bot is **no longer on ECS/Fargate** — do not reintroduce an ECS
 deploy. `task-definition.json` is a leftover from that era and is unused.
 
-**CD pipeline** ([.github/workflows/deploy.yml](.github/workflows/deploy.yml)): push the commit
-you want live to the **`deploy` branch** (`git push origin develop:deploy`) — or run the workflow
-manually. It builds the image, pushes it to ECR (`vudrochka-bot`, commit-SHA + `latest` tags), then
+**CD pipeline** ([.github/workflows/deploy.yml](.github/workflows/deploy.yml)): runs on **every
+push/merge to `develop`** (or manual dispatch). It first lints + tests (the deploy is gated on that
+passing), then builds the image, pushes it to ECR (`vudrochka-bot`, commit-SHA + `latest` tags),
 SSHes into the box, renders [compose.prod.yaml](compose.prod.yaml) with the pinned image URI, and
 `docker compose pull && up -d`. **The box never builds** — it pulls the pre-built image; ECR auth is
-a short-lived token minted on the runner (OIDC), so the box holds no AWS credentials.
+a short-lived token minted on the runner (OIDC), so the box holds no AWS credentials. ([ci.yml](.github/workflows/ci.yml)
+runs the same lint+test on pull requests; `develop` pushes are covered by the deploy gate.)
 
 **No GitHub secrets.** AWS is reached by assuming the IAM role
 `github-actions-vudrochka-deploy` via GitHub OIDC (the role ARN is hardcoded in the workflow — an


### PR DESCRIPTION
## Why

The deploy never ran: it was gated to a `deploy` branch that was never pushed, so merging to `develop` only ran CI. That mismatch is why changes never deployed.

## Change

- **deploy.yml** now triggers on **push to `develop`** (every merge) + manual dispatch. A `test` job (lint + pytest) runs first and the `deploy` job is `needs: test`, so a failing check **blocks** the deploy — broken code never reaches the box. The OIDC role already trusts the `develop` ref, so no AWS change is needed.
- **ci.yml** narrowed to pull requests (+ manual) so a merge does not run the same lint+test twice (the deploy gate covers `develop`).

## Effect

Merging this PR is itself a push to `develop`, so it will be the **first real deploy** — lint+test, build, push to ECR, then roll the Lightsail box. Since the move-fix (#17) is already on `develop`, that fix ships to the live bot with this deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)