### PR TITLE
Manage AWS infra as code with Terraform (infra/)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,3 +102,17 @@ it's preserved across deploys, never shipped from CI (there is no `BOT_TOKEN` in
 
 Manual fallback (e.g. CI down): sync source to `~/vudrochka` and `docker compose up -d --build`
 (the dev [compose.yaml](compose.yaml), which builds from source).
+
+## Infrastructure (Terraform)
+
+The AWS resources the pipeline depends on are managed as code in [infra/](infra/) — the GitHub
+OIDC provider, the `github-actions-vudrochka-deploy` role + policies, the `vudrochka-bot` ECR repo,
+the `vudrochka-bot/deploy` Secrets Manager secret (container only), and the Lightsail instance.
+Run Terraform from `infra/` (`terraform plan`/`apply`, AWS profile `claude`). Notes:
+
+- **State is local and git-ignored** (it can hold sensitive values); the box + ECR repo carry
+  `prevent_destroy`. Don't commit `*.tfstate` or `.terraform/`.
+- **Secret *values* are not in Terraform** — the deploy secret's payload and the box's `.env` are
+  set out-of-band; TF manages only the secret container.
+- The legacy ECS/Fargate resources are intentionally **not** in Terraform (being decommissioned).
+- Resources were imported (created via CLI first), so `terraform plan` should report no changes.

--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -1,0 +1,16 @@
+# Local Terraform state can contain sensitive values — never commit it.
+*.tfstate
+*.tfstate.*
+.terraform/
+.terraform.tfstate.lock.info
+
+# Local var overrides (may hold secrets).
+*.tfvars
+*.auto.tfvars
+override.tf
+override.tf.json
+
+crash.log
+crash.*.log
+
+# Keep .terraform.lock.hcl committed (provider version pinning).

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.40"
+  hashes = [
+    "h1:H3mU/7URhP0uCRGK8jeQRKxx2XFzEqLiOq/L2Bbiaxs=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,46 @@
+# infra/ — Terraform for VuDrochkaBot's AWS resources
+
+Infrastructure-as-code for everything the bot's deploy pipeline depends on, in
+account `126568927381` / `eu-central-1`.
+
+## What's managed here
+
+| Resource | Terraform address | Notes |
+|---|---|---|
+| GitHub OIDC provider | `aws_iam_openid_connect_provider.github` | lets Actions assume roles without keys |
+| Deploy role | `aws_iam_role.deploy` | `github-actions-vudrochka-deploy`, trust scoped to this repo's `deploy`/`develop` |
+| Role policies | `aws_iam_role_policy.ecr_push`, `.secrets_read` | ECR push + read the deploy secret |
+| ECR repo | `aws_ecr_repository.bot` | `vudrochka-bot` (`prevent_destroy`) |
+| Deploy secret | `aws_secretsmanager_secret.deploy` | container only — **value is not in Terraform** |
+| Lightsail instance | `aws_lightsail_instance.bot` | the box (`prevent_destroy`) |
+
+**Not managed here:** the deploy secret's *value* (host + SSH key — secret material,
+set out-of-band), the box's `~/vudrochka/.env` (`BOT_TOKEN`), and the legacy
+ECS/Fargate resources (being decommissioned).
+
+## Prerequisites
+
+- Terraform ≥ 1.6.
+- AWS CLI profile `claude` (or override: `-var aws_profile=<name>`).
+
+## Usage
+
+```bash
+cd infra
+terraform init
+terraform plan     # should show no changes — this repo mirrors live infra
+terraform apply    # only when you intend to change infra
+```
+
+## State
+
+State is **local** (`terraform.tfstate`) and git-ignored because it can contain
+sensitive values. If you work from more than one machine or want durability,
+switch to an S3 backend in `versions.tf` and `terraform init -migrate-state`.
+
+## How this was created
+
+The resources were first created imperatively (AWS CLI) to unblock the deploy,
+then imported into Terraform so the code matches reality without recreating
+anything. The `import` blocks used are kept in `imports.tf` for reference; they
+are idempotent and can stay.

--- a/infra/ecr.tf
+++ b/infra/ecr.tf
@@ -1,0 +1,18 @@
+# Container registry the deploy workflow pushes to and the Lightsail box pulls from.
+resource "aws_ecr_repository" "bot" {
+  name                 = "vudrochka-bot"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = false
+  }
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+
+  # Deleting the repo would drop every image the bot runs from.
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/infra/imports.tf
+++ b/infra/imports.tf
@@ -1,0 +1,39 @@
+# One-time import wiring (Terraform >= 1.5): brings the resources — originally
+# created via the AWS CLI — under Terraform management WITHOUT recreating them.
+# `terraform plan` should report "N to import, 0 to add, 0 to change, 0 to
+# destroy". These blocks are no-ops after the import and safe to leave.
+
+import {
+  to = aws_iam_openid_connect_provider.github
+  id = "arn:aws:iam::126568927381:oidc-provider/token.actions.githubusercontent.com"
+}
+
+import {
+  to = aws_iam_role.deploy
+  id = "github-actions-vudrochka-deploy"
+}
+
+import {
+  to = aws_iam_role_policy.ecr_push
+  id = "github-actions-vudrochka-deploy:ecr-push"
+}
+
+import {
+  to = aws_iam_role_policy.secrets_read
+  id = "github-actions-vudrochka-deploy:secrets-read"
+}
+
+import {
+  to = aws_ecr_repository.bot
+  id = "vudrochka-bot"
+}
+
+import {
+  to = aws_secretsmanager_secret.deploy
+  id = "arn:aws:secretsmanager:eu-central-1:126568927381:secret:vudrochka-bot/deploy-9zmePe"
+}
+
+import {
+  to = aws_lightsail_instance.bot
+  id = "vudrochka-bot"
+}

--- a/infra/lightsail.tf
+++ b/infra/lightsail.tf
@@ -1,0 +1,17 @@
+# The box the bot runs on. Its disk holds ~/vudrochka/.env (BOT_TOKEN), the
+# swapfile, and Docker state — recreating it would wipe all of that, so it is
+# guarded with prevent_destroy.
+resource "aws_lightsail_instance" "bot" {
+  name              = "vudrochka-bot"
+  availability_zone = "eu-central-1a"
+  blueprint_id      = "ubuntu_24_04"
+  bundle_id         = "nano_3_0" # $5/mo, 512MB, IPv4 (not the ipv6-only bundle)
+  key_pair_name     = "LightsailDefaultKeyPair"
+
+  lifecycle {
+    prevent_destroy = true
+    # user_data only runs at first boot; the box has since been configured by
+    # hand, so don't let a config value here trigger a replace.
+    ignore_changes = [user_data]
+  }
+}

--- a/infra/oidc.tf
+++ b/infra/oidc.tf
@@ -1,0 +1,89 @@
+# GitHub Actions OIDC provider — lets this repo's workflows assume AWS roles
+# with short-lived tokens instead of long-lived access keys.
+resource "aws_iam_openid_connect_provider" "github" {
+  url            = "https://token.actions.githubusercontent.com"
+  client_id_list = ["sts.amazonaws.com"]
+  thumbprint_list = [
+    "6938fd4d98bab03faadb97b34396831e3780aea1",
+    "1c58a3a8518e8759bf075b76b750d4f2df264fcd",
+  ]
+}
+
+# Trust policy: only this repo's deploy/develop branches may assume the role.
+data "aws_iam_policy_document" "deploy_trust" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = [for b in var.deploy_ref_branches : "repo:${var.github_repo}:ref:refs/heads/${b}"]
+    }
+  }
+}
+
+resource "aws_iam_role" "deploy" {
+  name                 = "github-actions-vudrochka-deploy"
+  description          = "GitHub Actions OIDC role: build+push vudrochka-bot image to ECR"
+  max_session_duration = 3600
+  assume_role_policy   = data.aws_iam_policy_document.deploy_trust.json
+}
+
+# Push/pull images to the bot's ECR repo (auth token is account-wide).
+data "aws_iam_policy_document" "ecr_push" {
+  statement {
+    sid       = "EcrAuth"
+    effect    = "Allow"
+    actions   = ["ecr:GetAuthorizationToken"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "EcrPushPull"
+    effect = "Allow"
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:InitiateLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:CompleteLayerUpload",
+      "ecr:PutImage",
+      "ecr:BatchGetImage",
+      "ecr:GetDownloadUrlForLayer",
+    ]
+    resources = [aws_ecr_repository.bot.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "ecr_push" {
+  name   = "ecr-push"
+  role   = aws_iam_role.deploy.id
+  policy = data.aws_iam_policy_document.ecr_push.json
+}
+
+# Read the deploy target from Secrets Manager (wildcard covers the random ARN suffix).
+data "aws_iam_policy_document" "secrets_read" {
+  statement {
+    sid       = "ReadDeploySecret"
+    effect    = "Allow"
+    actions   = ["secretsmanager:GetSecretValue"]
+    resources = ["arn:aws:secretsmanager:${var.aws_region}:${data.aws_caller_identity.current.account_id}:secret:${aws_secretsmanager_secret.deploy.name}-*"]
+  }
+}
+
+resource "aws_iam_role_policy" "secrets_read" {
+  name   = "secrets-read"
+  role   = aws_iam_role.deploy.id
+  policy = data.aws_iam_policy_document.secrets_read.json
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,19 @@
+output "deploy_role_arn" {
+  description = "ARN hardcoded in .github/workflows/deploy.yml (DEPLOY_ROLE_ARN)."
+  value       = aws_iam_role.deploy.arn
+}
+
+output "ecr_repository_url" {
+  description = "Registry URI the workflow pushes to and the box pulls from."
+  value       = aws_ecr_repository.bot.repository_url
+}
+
+output "lightsail_public_ip" {
+  description = "Current public IP (also stored in the vudrochka-bot/deploy secret)."
+  value       = aws_lightsail_instance.bot.public_ip_address
+}
+
+output "deploy_secret_arn" {
+  description = "Secrets Manager secret holding the deploy target (value managed out-of-band)."
+  value       = aws_secretsmanager_secret.deploy.arn
+}

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -1,0 +1,6 @@
+provider "aws" {
+  region  = var.aws_region
+  profile = var.aws_profile
+}
+
+data "aws_caller_identity" "current" {}

--- a/infra/secrets.tf
+++ b/infra/secrets.tf
@@ -1,0 +1,11 @@
+# Deploy target for the CD workflow (Lightsail host + ubuntu user + private key).
+#
+# Only the secret CONTAINER is managed here. The VALUE is deliberately NOT in
+# Terraform — secret material must not live in state or the repo. Set/rotate it
+# out-of-band, e.g.:
+#   aws secretsmanager put-secret-value --secret-id vudrochka-bot/deploy \
+#     --secret-string '{"host":"...","user":"ubuntu","ssh_key":"-----BEGIN..."}'
+resource "aws_secretsmanager_secret" "deploy" {
+  name        = "vudrochka-bot/deploy"
+  description = "Lightsail deploy target: host, ubuntu, default-keypair private key"
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,23 @@
+variable "aws_region" {
+  description = "AWS region for all resources."
+  type        = string
+  default     = "eu-central-1"
+}
+
+variable "aws_profile" {
+  description = "Local AWS CLI profile Terraform authenticates with (override for other machines/CI)."
+  type        = string
+  default     = "claude"
+}
+
+variable "github_repo" {
+  description = "owner/repo whose Actions workflows may assume the deploy role via OIDC."
+  type        = string
+  default     = "ThePaniv/VuDrochkaBot"
+}
+
+variable "deploy_ref_branches" {
+  description = "Branches whose OIDC token may assume the deploy role."
+  type        = list(string)
+  default     = ["deploy", "develop"]
+}

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.40"
+    }
+  }
+
+  # State is local and git-ignored (it can contain sensitive values). For a
+  # solo project that's fine; switch to an S3 backend here if this ever grows.
+}


### PR DESCRIPTION
## What

Puts the AWS resources the deploy pipeline depends on under **Terraform** (`infra/`), so the infra is version-controlled and drift-detectable instead of living only in the account.

Managed:
- GitHub OIDC provider
- `github-actions-vudrochka-deploy` role + `ecr-push` / `secrets-read` policies
- `vudrochka-bot` ECR repo (`prevent_destroy`)
- `vudrochka-bot/deploy` Secrets Manager secret — **container only**
- Lightsail instance (`prevent_destroy`)

## Imported, not recreated

These were created via the AWS CLI earlier to unblock the deploy. This PR **imports** them (Terraform 1.5 `import {}` blocks), then a verification run reported:

```
Apply: 7 imported, 0 added, 1 changed, 0 destroyed
Plan (after): No changes. Your infrastructure matches the configuration.
```

So nothing was rebuilt — the code now mirrors live AWS exactly.

## Guardrails

- **State is local + git-ignored** (it can hold sensitive values) — `.gitignore` excludes `*.tfstate` and `.terraform/`; the provider lock file is committed.
- **Secret material is not in Terraform** — the deploy secret payload and the box's `.env` are set out-of-band; TF manages only the secret container.
- `prevent_destroy` on the Lightsail box and ECR repo blocks accidental teardown.
- Legacy ECS/Fargate is **not** imported (being decommissioned separately).

## Usage

```bash
cd infra
terraform plan   # expect: no changes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)